### PR TITLE
feat: version subcommand, .gitignore fix, fish shell wrapper (fixes #21, #24, #25, #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gotocli.exe
 gotocli-mac-intel
 gotocli-mac-arm
 gotocli-linux
+builds/

--- a/app/main.go
+++ b/app/main.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+// version is stamped at release time via -ldflags.
+var version = "dev"
+
 type Store struct {
 	Directories map[string]string `json:"directories"`
 }
@@ -42,6 +45,15 @@ func saveStore(store Store) error {
 func main() {
 
 	args := os.Args
+
+	// Handle version before the argument guard so that both
+	// "gotocli version" and "gotocli --version" work.
+	if len(args) >= 2 {
+		if args[1] == "version" || args[1] == "--version" || args[1] == "-v" {
+			fmt.Println(version)
+			return
+		}
+	}
 
 	if len(args) < 3 {
 		fmt.Println("Usage: gotocli goto <command> [name] [path]")


### PR DESCRIPTION
Fixes #21, #24, #25, #26

## Changes

### 1. Version subcommand (#21)
Added `version` as a compile-time variable (stamped via `-ldflags` at release time, defaults to `dev`). Both `gotocli version` and `gotocli --version` / `gotocli -v` now print the version and exit. The `len(args) < 3` guard is bypassed for version flags so they work with zero subcommand arguments.

### 2. .gitignore (#24)
Added `builds/` to .gitignore so new build targets won't accidentally get committed.

### 3. Shell wrapper note (#25)
Added a note above the bash/zsh wrapper telling users to replace `gotocli` with their actual installation path. This avoids the silent failure where a missing binary causes `jump` to fail.

### 4. Fish shell wrapper (#26)
Added a fish shell wrapper section to the README, since fish users cannot use the `jump` command without a wrapper (fish doesn't share shell functions with bash/zsh).