### PR TITLE
fix: vet/test/ldflags/SHA-pin in release workflow (fixes #19, #22)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,21 +12,30 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Set up Go
-              uses: actions/setup-go@v4
+              uses: actions/setup-go@v5
               with:
                   go-version: "1.21"
 
+            - name: Run go vet
+              run: go vet ./...
+
+            - name: Run go test
+              run: go test ./...
+
             - name: Build all platforms
+              env:
+                  VERSION: ${{ github.ref_name }}
               run: |
-                  GOOS=darwin GOARCH=amd64 go build -o builds/gotocli-mac-intel app/main.go
-                  GOOS=darwin GOARCH=arm64 go build -o builds/gotocli-mac-arm app/main.go
-                  GOOS=linux GOARCH=amd64 go build -o builds/gotocli-linux app/main.go
-                  GOOS=windows GOARCH=amd64 go build -o builds/gotocli.exe app/main.go
+                  LDFLAGS="-ldflags -X main.version=$VERSION"
+                  GOOS=darwin GOARCH=amd64 go build -o builds/gotocli-mac-intel -ldflags "-X main.version=$VERSION" app/main.go
+                  GOOS=darwin GOARCH=arm64 go build -o builds/gotocli-mac-arm -ldflags "-X main.version=$VERSION" app/main.go
+                  GOOS=linux GOARCH=amd64 go build -o builds/gotocli-linux -ldflags "-X main.version=$VERSION" app/main.go
+                  GOOS=windows GOARCH=amd64 go build -o builds/gotocli.exe -ldflags "-X main.version=$VERSION" app/main.go
 
             - name: Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               with:
                   files: builds/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
             - name: Set up Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
               with:
                   go-version: "1.21"
 
@@ -36,6 +36,6 @@ jobs:
                   GOOS=windows GOARCH=amd64 go build -o builds/gotocli.exe -ldflags "-X main.version=$VERSION" app/main.go
 
             - name: Release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
               with:
                   files: builds/*


### PR DESCRIPTION
Fixes #19, #22

The release workflow compiled and published binaries without running `go vet` or `go test`. A tag pushed on a commit that never went through the CI workflow would be published with no checks at all. Additionally, all action references used floating major tags that could be repointed by a compromised maintainer account.

Changes:
- **Vet/test** (#22): Added `go vet ./...` and `go test ./...` before build
- **Version stamp** (#22): Added `-ldflags -X main.version=$VERSION` to all build commands so the `version` variable from #21 is stamped at release time. `VERSION` is derived from `github.ref_name` (the tag name, e.g. `v1.0.0`)
- **Action upgrades**: `actions/checkout` v3→v4, `actions/setup-go` v4→v5, `softprops/action-gh-release` v1→v2
- **SHA pinning** (#19): Pinned all actions to commit SHAs to prevent supply-chain attacks via floating tags:
  - `actions/checkout@11d5960a326750d5838078e36cf38b85af677262` (v4.4.0)
  - `actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff` (v5.0.0)
  - `softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (v2.0.0)